### PR TITLE
Make the editor usable without sound

### DIFF
--- a/leviathan.vcxproj
+++ b/leviathan.vcxproj
@@ -583,6 +583,7 @@ shader_minifier.exe -v -o src\shaders\post.inl src\shaders\post.frag</Command>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Snapshot|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Heavy Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\song.cpp">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,9 +83,13 @@ int __cdecl main(int argc, char* argv[])
 		Leviathan::Editor editor = Leviathan::Editor();
 		editor.updateShaders(&pidMain, &pidPost, true);
 
-		// absolute path always works here
-		// relative path works only when not ran from visual studio directly
-		Leviathan::Song track(L"audio.wav");
+		#if USE_AUDIO
+			// absolute path always works here
+			// relative path works only when not ran from visual studio directly
+			Leviathan::Song track(L"audio.wav");
+		#else
+			Leviathan::NoSong track;
+		#endif
 		track.play();
 		double position = 0.0;
 	#endif

--- a/src/song.cpp
+++ b/src/song.cpp
@@ -50,28 +50,25 @@ Song::~Song()
 	mediaSeeking->Release();
 }
 
-int Song::play()
+void Song::play()
 {
 	mediaControl->Run();
 	playing = true;
-	return 0;
 }
 
-int Song::pause()
+void Song::pause()
 {
 	mediaControl->Stop();
 	playing = false;
-	return 0;
 }
 
-int Song::toggle()
+void Song::toggle()
 {
 	playing = !playing;
 	if (playing)
 		play();
 	else
 		pause();
-	return 0;
 }
 
 bool Song::is_playing()
@@ -84,7 +81,7 @@ bool Song::is_playing()
 	return position<trackLength;
 }
 
-int Song::seek(long double position)
+void Song::seek(long double position)
 {
 	if (position>length)
 		position = length;
@@ -98,8 +95,6 @@ int Song::seek(long double position)
 	mediaSeeking->SetPositions(&seekPosition, AM_SEEKING_AbsolutePositioning, &seekPosition, AM_SEEKING_NoPositioning);
 	if (playing)
 		mediaControl->Run();
-
-	return 0;
 }
 
 long double Song::getTime()

--- a/src/song.h
+++ b/src/song.h
@@ -15,19 +15,19 @@ namespace Leviathan
 
 		~Song();
 
-		int play();
+		virtual void play();
 
-		int pause();
+		virtual void pause();
 
-		int toggle();
+		virtual void toggle();
 
-		bool is_playing();
+		virtual bool is_playing();
 
-		int seek(long double position);
+		virtual void seek(long double position);
 
-		long double getTime();
+		virtual long double getTime();
 
-		long double getLength();
+		virtual long double getLength();
 
 	private:
 		long double length;
@@ -36,4 +36,63 @@ namespace Leviathan
 		IMediaSeeking * mediaSeeking;
 		IBasicAudio * audioControl;
 	};
+
+    // An implementation of the Song class that just handles the time.
+    class NoSong : public Song
+    {
+    public:
+        NoSong() : position(0.0), playing(false), lastTick(0) {}
+
+        ~NoSong() {}
+
+        void play() override {
+            if (!playing) {
+                playing = true;
+                lastTick = GetTickCount64();
+            }
+        }
+
+        void pause() override {
+            if (playing) {
+                playing = false;
+                position += getElapsedTime();
+            }
+        }
+
+        void toggle() override {
+            return playing ? pause() : play();
+        }
+
+        bool is_playing() override {
+            return playing;
+        }
+
+        void seek(long double position_) override {
+            position = position_;
+            if (playing) {
+                lastTick = GetTickCount64();  // Reset the tick count after seeking
+            }
+        }
+
+        long double getTime() override {
+            if (playing) {
+                return position + getElapsedTime();
+            }
+            return position;
+        }
+
+        long double getLength() override {
+            return 3600.0; // Arbitrary length (1 hour)
+        }
+
+    private:
+        long double position;
+        bool playing;
+        ULONGLONG lastTick;
+
+        long double getElapsedTime() const {
+            ULONGLONG currentTick = GetTickCount64();
+            return static_cast<long double>(currentTick - lastTick) / 1000.;
+        }
+    };
 }


### PR DESCRIPTION
When audio is disabled (e.g. we don't have a .wav file), use a fake Song class that just handles the time.

- Use void instead of useless ints in the Song class.
- Exclude editor.cpp when building for debug (it didn't build for me).